### PR TITLE
Update: dbw_node.py

### DIFF
--- a/ros/src/tests/test_tf_helper.py
+++ b/ros/src/tests/test_tf_helper.py
@@ -1,0 +1,117 @@
+"""
+Tests for tf_helper
+"""
+import styx_msgs.msg
+import geometry_msgs.msg
+
+import numpy as np
+
+import src.tl_detector.tf_helper as tf_helper
+
+
+def test_get_closest_traffic_light_ahead_of_car_first_light_closest():
+
+    first_light = styx_msgs.msg.TrafficLight()
+    first_light.pose.pose.position.x = 5
+    first_light.pose.pose.position.y = 0
+    first_light.pose.pose.position.z = 0
+
+    second_light = styx_msgs.msg.TrafficLight()
+    second_light.pose.pose.position.x = 7
+    second_light.pose.pose.position.y = 0
+    second_light.pose.pose.position.z = 0
+
+    traffic_lights = [first_light, second_light]
+
+    car_position = geometry_msgs.msg.Point()
+    car_position.x = 2
+    car_position.y = 0
+    car_position.z = 0
+
+    waypoints = []
+
+    for x in range(0, 10):
+
+        waypoint = styx_msgs.msg.Waypoint()
+        waypoint.pose.pose.position.x = x
+        waypoint.pose.pose.position.y = 0
+        waypoint.pose.pose.position.z = 0
+
+        waypoints.append(waypoint)
+
+    expected = first_light
+    actual = tf_helper.get_closest_traffic_light_ahead_of_car(traffic_lights, car_position, waypoints)
+
+    assert expected == actual
+
+
+def test_get_closest_traffic_light_ahead_of_car_second_light_closest():
+
+    first_light = styx_msgs.msg.TrafficLight()
+    first_light.pose.pose.position.x = 5
+    first_light.pose.pose.position.y = 0
+    first_light.pose.pose.position.z = 0
+
+    second_light = styx_msgs.msg.TrafficLight()
+    second_light.pose.pose.position.x = 3
+    second_light.pose.pose.position.y = 0
+    second_light.pose.pose.position.z = 0
+
+    traffic_lights = [first_light, second_light]
+
+    car_position = geometry_msgs.msg.Point()
+    car_position.x = 2
+    car_position.y = 0
+    car_position.z = 0
+
+    waypoints = []
+
+    for x in range(0, 10):
+
+        waypoint = styx_msgs.msg.Waypoint()
+        waypoint.pose.pose.position.x = x
+        waypoint.pose.pose.position.y = 0
+        waypoint.pose.pose.position.z = 0
+
+        waypoints.append(waypoint)
+
+    expected = second_light
+    actual = tf_helper.get_closest_traffic_light_ahead_of_car(traffic_lights, car_position, waypoints)
+
+    assert expected == actual
+
+
+def test_get_closest_traffic_light_ahead_of_car_car_at_end_of_track_closest_light_at_beginning_of_track():
+
+    first_light = styx_msgs.msg.TrafficLight()
+    first_light.pose.pose.position.x = 5
+    first_light.pose.pose.position.y = 0
+    first_light.pose.pose.position.z = 0
+
+    second_light = styx_msgs.msg.TrafficLight()
+    second_light.pose.pose.position.x = 7
+    second_light.pose.pose.position.y = 0
+    second_light.pose.pose.position.z = 0
+
+    traffic_lights = [first_light, second_light]
+
+    car_position = geometry_msgs.msg.Point()
+    car_position.x = 8
+    car_position.y = 0
+    car_position.z = 0
+
+    waypoints = []
+
+    for x in range(0, 10):
+
+        waypoint = styx_msgs.msg.Waypoint()
+        waypoint.pose.pose.position.x = x
+        waypoint.pose.pose.position.y = 0
+        waypoint.pose.pose.position.z = 0
+
+        waypoints.append(waypoint)
+
+    expected = first_light
+    actual = tf_helper.get_closest_traffic_light_ahead_of_car(traffic_lights, car_position, waypoints)
+
+    assert expected == actual

--- a/ros/src/tests/test_waypoints_helper.py
+++ b/ros/src/tests/test_waypoints_helper.py
@@ -172,43 +172,8 @@ def test_is_traffic_light_ahead_of_car_light_is_ahead_of_car():
     light_position.y = 0
     light_position.z = 0
 
-    max_distance = 5.0
-
     expected = True
-    actual = waypoints_helper.is_traffic_light_ahead_of_car(
-        waypoints, car_position, light_position, max_distance)
-
-    assert expected == actual
-
-
-def test_is_traffic_light_ahead_of_car_light_is_too_far_ahead_of_car():
-
-    waypoints = []
-
-    for x in range(0, 10):
-
-        waypoint = styx_msgs.msg.Waypoint()
-        waypoint.pose.pose.position.x = x
-        waypoint.pose.pose.position.y = 0
-        waypoint.pose.pose.position.z = 0
-
-        waypoints.append(waypoint)
-
-    car_position = geometry_msgs.msg.Point()
-    car_position.x = 2
-    car_position.y = 0
-    car_position.z = 0
-
-    light_position = geometry_msgs.msg.Point()
-    light_position.x = 8
-    light_position.y = 0
-    light_position.z = 0
-
-    max_distance = 5.0
-
-    expected = False
-    actual = waypoints_helper.is_traffic_light_ahead_of_car(
-        waypoints, car_position, light_position, max_distance)
+    actual = waypoints_helper.is_traffic_light_ahead_of_car(waypoints, car_position, light_position)
 
     assert expected == actual
 
@@ -236,11 +201,8 @@ def test_is_traffic_light_ahead_of_car_light_is_behind_the_car():
     light_position.y = 0
     light_position.z = 0
 
-    max_distance = 5.0
-
     expected = False
-    actual = waypoints_helper.is_traffic_light_ahead_of_car(
-        waypoints, car_position, light_position, max_distance)
+    actual = waypoints_helper.is_traffic_light_ahead_of_car(waypoints, car_position, light_position)
 
     assert expected == actual
 
@@ -268,10 +230,7 @@ def test_is_traffic_light_ahead_of_car_light_is_ahead_of_waypoints():
     light_position.y = 0
     light_position.z = 0
 
-    max_distance = 5.0
-
     expected = False
-    actual = waypoints_helper.is_traffic_light_ahead_of_car(
-        waypoints, car_position, light_position, max_distance)
+    actual = waypoints_helper.is_traffic_light_ahead_of_car(waypoints, car_position, light_position)
 
     assert expected == actual

--- a/ros/src/tests/test_waypoints_helper.py
+++ b/ros/src/tests/test_waypoints_helper.py
@@ -9,22 +9,6 @@ import numpy as np
 import src.waypoint_updater.waypoints_helper as waypoints_helper
 
 
-def test_get_distance_between_points():
-
-    first = geometry_msgs.msg.Point()
-    first.x = 0
-    first.y = 0
-
-    second = geometry_msgs.msg.Point()
-    second.x = 10
-    second.y = 20
-
-    expected = np.sqrt(500)
-    actual = waypoints_helper.get_distance_between_points(first, second)
-
-    assert np.isclose(expected, actual)
-
-
 def test_get_closest_waypoint_index():
 
     pose = geometry_msgs.msg.Pose()

--- a/ros/src/tl_detector/tf_helper.py
+++ b/ros/src/tl_detector/tf_helper.py
@@ -106,11 +106,9 @@ def get_info_about_closest_traffic_light_ahead_of_car(traffic_lights, car_positi
     if len(lights_waypoints_indices) == 0:
 
         light_index = 0
-        light_waypoint_index = get_closest_waypoint_index(traffic_lights[0].pose.pose.position, waypoints_matrix)
 
     else:
 
         light_index = sorted_traffic_lights_waypoint_indices[0][0]
-        light_waypoint_index = sorted_traffic_lights_waypoint_indices[0][1]
 
-    return traffic_lights[light_index], light_waypoint_index
+    return traffic_lights[light_index]

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -85,16 +85,9 @@ class TLDetector(object):
 
         if are_arguments_available:
 
-            waypoints_matrix = tf_helper.get_waypoints_matrix(self.waypoints)
-
             # Get closest traffic light
-
-            # For debugging(Ground Truth data)
-            # traffic_light, traffic_light_waypoint_index = tf_helper.get_info_about_closest_traffic_light_ahead_of_car(
-            # self.traffic_lights, self.car_pose.position, waypoints_matrix)
-
-            traffic_light = tf_helper.get_info_about_closest_traffic_light_ahead_of_car(
-                self.traffic_positions.lights, self.car_pose.position, waypoints_matrix)
+            traffic_light = tf_helper.get_closest_traffic_light_ahead_of_car(
+                self.traffic_positions.lights, self.car_pose.position, self.waypoints)
 
             # These values seem so be wrong - Udacity keeps on putting in config different values that what camera
             # actually publishes.

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -93,7 +93,7 @@ class TLDetector(object):
             # traffic_light, traffic_light_waypoint_index = tf_helper.get_info_about_closest_traffic_light_ahead_of_car(
             # self.traffic_lights, self.car_pose.position, waypoints_matrix)
 
-            traffic_light, traffic_light_waypoint_index = tf_helper.get_info_about_closest_traffic_light_ahead_of_car(
+            traffic_light = tf_helper.get_info_about_closest_traffic_light_ahead_of_car(
                 self.traffic_positions.lights, self.car_pose.position, waypoints_matrix)
 
             # These values seem so be wrong - Udacity keeps on putting in config different values that what camera

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -121,22 +121,30 @@ class DBWNode(object):
             rate.sleep()
 
     def publish(self, throttle, brake, steer):
+
         tcmd = ThrottleCmd()
         tcmd.enable = True
         tcmd.pedal_cmd_type = ThrottleCmd.CMD_PERCENT
         tcmd.pedal_cmd = throttle
-        self.throttle_pub.publish(tcmd)
 
         scmd = SteeringCmd()
         scmd.enable = True
         scmd.steering_wheel_angle_cmd = steer
-        self.steer_pub.publish(scmd)
 
         bcmd = BrakeCmd()
         bcmd.enable = True
         bcmd.pedal_cmd_type = BrakeCmd.CMD_TORQUE
         bcmd.pedal_cmd = brake
-        self.brake_pub.publish(bcmd)
+
+        if brake == 0:
+
+            self.throttle_pub.publish(tcmd)
+            self.steer_pub.publish(scmd)
+
+        if throttle == 0:
+
+            self.brake_pub.publish(bcmd)
+            self.steer_pub.publish(scmd)
 
     def twist_commands_cb(self, msg):
 

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -63,8 +63,8 @@ class DBWNode(object):
         self.previous_loop_time = rospy.get_rostime()
         self.previous_debug_time = rospy.get_rostime()
 
-        self.throttle_pid = pid.PID(kp=0.2, ki=0.005, kd=0.1, mn=decel_limit, mx=0.5 * accel_limit)
-        self.brake_pid = pid.PID(kp=100.0, ki=0.001, kd=0.1, mn=brake_deadband, mx=2000)
+        self.throttle_pid = pid.PID(kp=0.2, ki=0.01, kd=0.1, mn=decel_limit, mx=0.5 * accel_limit)
+        self.brake_pid = pid.PID(kp=30.0, ki=0.001, kd=5.0, mn=brake_deadband, mx=2000)
         self.steering_pid = pid.PID(kp=1.0, ki=0.001, kd=0.5, mn=-max_steer_angle, mx=max_steer_angle)
 
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -89,7 +89,7 @@ class WaypointUpdater(object):
 
                 base_waypoints = self.last_base_waypoints_lane.waypoints
 
-                smoothed_waypoints_around_car = waypoints_helper.get_dynamic_smooth_waypoints(
+                smoothed_waypoints_around_car = waypoints_helper.get_dynamic_smooth_waypoints_around_car(
                     base_waypoints, self.pose.position, LOOK_AHEAD_METRES, LOOK_BEHIND_METRES)
 
                 smooth_waypoints_matrix = waypoints_helper.get_waypoints_matrix(smoothed_waypoints_around_car)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -42,8 +42,9 @@ class WaypointUpdater(object):
         rospy.init_node('waypoint_updater')
 
         # TODO: Add other member variables you need below
-        self.last_base_waypoints_lane = \
-            None
+        self.last_base_waypoints_lane = None
+        self.last_base_waypoints_matrix = None
+
         self.upcoming_traffic_light_position = None
         self.upcoming_traffic_light_message_time = None
         self.current_linear_velocity = None
@@ -148,9 +149,8 @@ class WaypointUpdater(object):
 
                 self.final_waypoints_pub.publish(lane)
 
-                base_waypoints_matrix = waypoints_helper.get_waypoints_matrix(base_waypoints)
                 car_waypoint_index = waypoints_helper.get_closest_waypoint_index(
-                    self.pose.position, base_waypoints_matrix)
+                    self.pose.position, self.last_base_waypoints_matrix)
 
                 self.print_car_waypoint(car_waypoint_index)
 
@@ -163,6 +163,7 @@ class WaypointUpdater(object):
     def base_waypoints_cb(self, lane):
         # TODO: Implement
         self.last_base_waypoints_lane = lane
+        self.last_base_waypoints_matrix = waypoints_helper.get_waypoints_matrix(lane.waypoints)
 
         # if not os.path.exists(path):
         #     waypoints_helper.save_waypoints(lane.waypoints, path)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -122,7 +122,7 @@ class WaypointUpdater(object):
                             smoothed_waypoints_ahead[:light_id_in_smooth_waypoints])
 
                         # If we are close enough to traffic light that need to start braking
-                        if distance_to_traffic_light < 5.0 * np.power(self.current_linear_velocity, 1.2):
+                        if distance_to_traffic_light < 4.0 * np.power(self.current_linear_velocity, 1.2):
 
                             # Get braking path
                             self.braking_path_waypoints = waypoints_helper.get_braking_path_waypoints(

--- a/ros/src/waypoint_updater/waypoints_helper.py
+++ b/ros/src/waypoint_updater/waypoints_helper.py
@@ -237,7 +237,7 @@ def get_smooth_waypoints_ahead(base_waypoints, car_position, look_ahead_waypoint
     return smoothed_waypoints[look_behind_waypoints_count:]
 
 
-def get_dynamic_smooth_waypoints(waypoints, car_position, look_ahead_metres, look_behind_metres):
+def get_dynamic_smooth_waypoints_around_car(waypoints, car_position, look_ahead_metres, look_behind_metres):
     """
     Given base waypoints, car position and look ahead and behind metres, compute a smooth path around of the car.
     Path should stretch approximately look_behind_metres behind the carn and look_ahead_metres ahead of the car
@@ -258,29 +258,6 @@ def get_dynamic_smooth_waypoints(waypoints, car_position, look_ahead_metres, loo
     smoothed_waypoints = get_smoothed_out_waypoints(nearby_waypoints)
 
     return smoothed_waypoints
-
-
-def get_dynamic_smooth_waypoints_ahead(waypoints, car_position, look_ahead_metres, look_behind_metres):
-    """
-    Given base waypoints, car position and look ahead and behind metres, compute a smooth path ahead of the car.
-    :param waypoints: list of styx_msgs.msg.Waypoint instances
-    :param car_position: car position in base_waypoints
-    :param look_ahead_metres: float, roughly how many metres ahead of the car we should return
-    :param look_behind_metres: float, roughly how many metres behind the car we should consider to smooth the path
-    :return: list of styx_msgs.msg.Waypoint instances
-    """
-
-    waypoints_matrix = get_waypoints_matrix(waypoints)
-    car_waypoint_index = get_closest_waypoint_index(car_position, waypoints_matrix)
-
-    waypoints_behind = get_waypoints_behind_car(waypoints, car_waypoint_index, look_behind_metres)
-    waypoints_ahead = get_waypoints_ahead_of_car(waypoints, car_waypoint_index, look_ahead_metres)
-
-    nearby_waypoints = waypoints_behind + waypoints_ahead
-    smoothed_waypoints = get_smoothed_out_waypoints(nearby_waypoints)
-
-    # Only report waypoints ahead of car
-    return smoothed_waypoints[len(waypoints_behind):]
 
 
 def get_waypoints_ahead_of_car(waypoints, car_waypoint_index, distance):

--- a/ros/src/waypoint_updater/waypoints_helper.py
+++ b/ros/src/waypoint_updater/waypoints_helper.py
@@ -23,20 +23,6 @@ def get_waypoints_matrix(waypoints):
     return waypoints_matrix
 
 
-def get_distance_between_points(first, second):
-    """
-    Return distance between two points
-    :param first: geometry_msgs.msgs.Point instance
-    :param second: geometry_msgs.msgs.Point instance
-    :return: float
-    """
-
-    x_difference = first.x - second.x
-    y_difference = first.y - second.y
-
-    return np.sqrt(x_difference**2 + y_difference**2)
-
-
 def get_closest_waypoint_index(position, waypoints_matrix):
     """
     Given a pose and waypoints list, return index of waypoint closest to pose

--- a/ros/src/waypoint_updater/waypoints_helper.py
+++ b/ros/src/waypoint_updater/waypoints_helper.py
@@ -144,12 +144,12 @@ def get_braking_path_waypoints(waypoints, current_velocity, traffic_light_waypoi
     :return: list of styx_msgs.msg.Waypoint instances
     """
 
-    offset = 1
+    offset = 0
     stop_id = traffic_light_waypoint_id - offset
 
     # Set target velocity to -1, to force car to brake to full stop. With velocity 0 braking from PID might not
     # be strong enough to really stop the car
-    final_velocity = -1.0
+    final_velocity = -0.2
 
     braking_waypoints = []
 
@@ -160,7 +160,7 @@ def get_braking_path_waypoints(waypoints, current_velocity, traffic_light_waypoi
 
         # For velocities in front of stop light that would be very low, set them to a small positive value.
         # This is so we don't end up stopping too early, e.g. 5m before stop line
-        rolling_velocity = 0.1
+        rolling_velocity = 0.2
         velocity = max(rolling_velocity, velocity)
 
         waypoint.twist.twist.linear.x = velocity


### PR DESCRIPTION
Update PID values in dbw_node.py

I updated the PID values to try and reduce oscillation following the waypoints and overshoot at the stop lights. The model tended to perform well at both low speed (ref 9.0) and high speed (ref 40.0).

- Change throttle controller PID values to kp = 0.5, kd, ki = 0.0. The integral and derivative controls are not needed as the low speed does not result in oscillation or instability.

- Change brake controller PID values to kp = 250.0, kd = 2.5, and ki = 0.0. The brake event relates to high-speed dynamics, therefore the derivative control can be used to estimate future positions and correct. This seems to correct the overshoot at stop lights. The integral control tends to create an overshoot condition, therefore it was removed.

- Change steering control to kp = 0.5, ki = 0.0, kd = 1.0. The integral control was removed as it reduced oscillations when the car was tested at high speed. The steering aspect was minimally improved at low speed.